### PR TITLE
refactor: redesign match screen with immersive table layout and card …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.*
 # agents
 .agents/
 docs/
+.kiro

--- a/src/components/organisms/Match/ActivityLogOverlay.tsx
+++ b/src/components/organisms/Match/ActivityLogOverlay.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text } from '@/components/atoms/Text';
+import { useTheme } from '@/theme/hooks/useTheme';
+import type { PublicActionPayload } from '@/types/multiplayer.types';
+import { translateLog } from '@/utils/cardTranslations';
+
+interface ActivityLogOverlayProps {
+  log: PublicActionPayload[];
+}
+
+export function ActivityLogOverlay({ log }: ActivityLogOverlayProps) {
+  const { fonts } = useTheme();
+
+  if (log.length === 0) return null;
+
+  return (
+    <View style={styles.container}>
+      {log.slice(0, 3).map((item, i) => (
+        <View key={i} testID="log-entry">
+          <Text style={[styles.logText, { fontFamily: fonts.family.aldrich }]}>
+            <Text style={styles.playerName}>{item.playerName}</Text>
+            {' — '}
+            {translateLog(item.effectDescription)}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    right: 12,
+    top: 72,
+    maxWidth: 200,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    borderRadius: 10,
+    borderCurve: 'continuous',
+    borderWidth: 1,
+    borderColor: 'rgba(59,130,246,0.2)',
+    padding: 8,
+    gap: 4,
+  },
+  logText: {
+    fontSize: 11,
+    lineHeight: 16,
+    color: '#94A3B8',
+  },
+  playerName: {
+    color: '#60A5FA',
+  },
+});

--- a/src/components/organisms/Match/CardBack.tsx
+++ b/src/components/organisms/Match/CardBack.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, StyleSheet, ViewStyle } from 'react-native';
+import { AstronautIcon } from '@/components/svg/svgIcons';
+
+interface CardBackProps {
+  rotation: number;
+  offsetX?: number;
+  style?: ViewStyle;
+}
+
+export function CardBack({ rotation, offsetX = 0, style }: CardBackProps) {
+  return (
+    <View
+      testID="card-back"
+      style={[
+        styles.card,
+        {
+          transform: [{ translateX: offsetX }, { rotate: `${rotation}deg` }],
+        },
+        style,
+      ]}
+    >
+      <AstronautIcon color="#1E3A5F" size={28} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    width: 45,
+    height: 65,
+    backgroundColor: '#0F172A',
+    borderRadius: 8,
+    borderCurve: 'continuous',
+    borderWidth: 1.5,
+    borderColor: 'rgba(59,130,246,0.3)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    position: 'absolute',
+  },
+});

--- a/src/components/organisms/Match/HUDOverlay.tsx
+++ b/src/components/organisms/Match/HUDOverlay.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { View, Pressable, StyleSheet } from 'react-native';
+import { Text } from '@/components/atoms/Text';
+import { Feather } from '@expo/vector-icons';
+import { useTheme } from '@/theme/hooks/useTheme';
+import { Card } from '@/types/multiplayer.types';
+
+export interface HUDOverlayProps {
+  isMyTurn: boolean;
+  selectedCard: Card | null;
+  nickname: string;
+  onConfirmPlay: () => void;
+  onSync: () => void;
+  /** Progresso do timer: 1.0 = início, 0.0 = expirado. Undefined = sem timer */
+  timerProgress?: number;
+}
+
+export function HUDOverlay({
+  isMyTurn,
+  selectedCard,
+  nickname,
+  onConfirmPlay,
+  onSync,
+  timerProgress,
+}: HUDOverlayProps) {
+  const { fonts } = useTheme();
+
+  const isPlayEnabled = isMyTurn && selectedCard !== null;
+
+  // Cor da barra: verde → amarelo → vermelho conforme o tempo passa
+  const timerColor =
+    timerProgress === undefined
+      ? '#10B981'
+      : timerProgress > 0.5
+        ? '#10B981'
+        : timerProgress > 0.25
+          ? '#F59E0B'
+          : '#EF4444';
+
+  const showTimer = isMyTurn && timerProgress !== undefined;
+
+  return (
+    <View style={styles.overlay}>
+      {/* Nickname + Sync button — top-left */}
+      <View style={[styles.nicknameRow, { pointerEvents: 'auto' }]}>
+        <Text
+          style={[styles.nicknameText, { fontFamily: fonts.family.aldrich }]}
+        >
+          {nickname}
+        </Text>
+        <Pressable onPress={onSync} style={styles.syncBtn}>
+          <Feather name="refresh-cw" size={13} color="#94A3B8" />
+        </Pressable>
+      </View>
+
+      {/* TurnIndicator badge + timer — top-right */}
+      <View style={[styles.turnBadgeWrapper, { pointerEvents: 'auto' }]}>
+        <View
+          style={[
+            styles.turnBadge,
+            {
+              backgroundColor: isMyTurn
+                ? 'rgba(16,185,129,0.15)'
+                : 'rgba(239,68,68,0.1)',
+              borderColor: isMyTurn ? '#10B981' : '#EF4444',
+            },
+          ]}
+        >
+          <Feather
+            name={isMyTurn ? 'zap' : 'clock'}
+            size={14}
+            color={isMyTurn ? '#10B981' : '#EF4444'}
+          />
+          <Text
+            style={[
+              styles.turnBadgeText,
+              {
+                fontFamily: fonts.family.aldrich,
+                color: isMyTurn ? '#10B981' : '#EF4444',
+              },
+            ]}
+          >
+            {isMyTurn ? 'Seu Turno' : 'Aguardando'}
+          </Text>
+        </View>
+
+        {/* Barra de progresso do timer — só visível no turno do jogador */}
+        {showTimer && (
+          <View style={styles.timerBarTrack}>
+            <View
+              style={[
+                styles.timerBarFill,
+                {
+                  width: `${(timerProgress ?? 1) * 100}%`,
+                  backgroundColor: timerColor,
+                },
+              ]}
+            />
+          </View>
+        )}
+      </View>
+
+      {/* PlayButton — bottom-right */}
+      <Pressable
+        testID="play-button"
+        style={[
+          styles.playButton,
+          {
+            pointerEvents: 'auto',
+            backgroundColor: isPlayEnabled
+              ? 'rgba(59,130,246,0.9)'
+              : 'rgba(31,41,55,0.5)',
+          },
+        ]}
+        onPress={onConfirmPlay}
+        disabled={!isPlayEnabled}
+      >
+        <Feather
+          name="play"
+          size={24}
+          color={isPlayEnabled ? 'white' : '#4B5563'}
+        />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    pointerEvents: 'box-none',
+  },
+  nicknameRow: {
+    position: 'absolute',
+    top: 8,
+    left: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  nicknameText: {
+    color: '#94A3B8',
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  syncBtn: {
+    padding: 6,
+  },
+  turnBadgeWrapper: {
+    position: 'absolute',
+    top: 8,
+    right: 12,
+    alignItems: 'stretch',
+    gap: 4,
+  },
+  turnBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 20,
+    borderWidth: 1,
+  },
+  turnBadgeText: {
+    fontSize: 10,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  timerBarTrack: {
+    height: 3,
+    borderRadius: 2,
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    overflow: 'hidden',
+  },
+  timerBarFill: {
+    height: '100%',
+    borderRadius: 2,
+  },
+  playButton: {
+    position: 'absolute',
+    bottom: 16,
+    right: 16,
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/components/organisms/Match/OpponentArea.tsx
+++ b/src/components/organisms/Match/OpponentArea.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { View, Image, StyleSheet } from 'react-native';
+import { Text } from '@/components/atoms/Text';
+import { useTheme } from '@/theme/hooks/useTheme';
+import { AstronautIcon } from '@/components/svg/svgIcons';
+import { PlayerInfo } from '@/types/multiplayer.types';
+import { CardBack } from './CardBack';
+
+interface OpponentAreaProps {
+  opponent: PlayerInfo | undefined;
+  isOpponentTurn: boolean;
+}
+
+const FAN_ANGLE_STEP = 5; // graus — leque mais suave
+const FAN_CARD_WIDTH = 52;
+// Espaçamento horizontal entre CardBacks
+const getFanHorizontalStep = (count: number) =>
+  Math.max(16, Math.min(FAN_CARD_WIDTH * 0.8, 160 / Math.max(count - 1, 1)));
+
+export function OpponentArea({ opponent, isOpponentTurn }: OpponentAreaProps) {
+  const { fonts } = useTheme();
+
+  if (!opponent) return null;
+
+  const cardsCount: number =
+    (opponent.hand as any)?.count ?? (opponent.hand as any)?.length ?? 0;
+
+  const visibleCount = Math.min(cardsCount, 7);
+
+  return (
+    <View style={styles.container}>
+      {/* Avatar + info row */}
+      <View style={styles.infoRow}>
+        <View style={styles.avatarWrapper}>
+          <View
+            style={[
+              styles.avatarContainer,
+              isOpponentTurn && styles.avatarTurnGlow,
+            ]}
+          >
+            {opponent.avatar ? (
+              <Image
+                source={{ uri: opponent.avatar }}
+                style={styles.avatarImage}
+              />
+            ) : (
+              <AstronautIcon
+                color="#3B82F6"
+                armColor="#093075"
+                armStrokeColor="#3B82F6"
+                size={36}
+              />
+            )}
+          </View>
+          {opponent.isEliminated && (
+            <View style={styles.eliminatedBadge}>
+              <Text style={styles.eliminatedText}>Eliminado</Text>
+            </View>
+          )}
+        </View>
+        <View style={styles.nameColumn}>
+          <Text
+            style={[styles.opponentName, { fontFamily: fonts.family.aldrich }]}
+            numberOfLines={1}
+          >
+            {opponent.name}
+          </Text>
+          <Text
+            style={[styles.cardCount, { fontFamily: fonts.family.aldrich }]}
+          >
+            {cardsCount} cartas
+          </Text>
+        </View>
+      </View>
+
+      {/* Fan layout of CardBacks */}
+      {visibleCount > 0 && (
+        <View style={styles.fanContainer}>
+          {Array.from({ length: visibleCount }, (_, i) => {
+            const rotation = (i - (visibleCount - 1) / 2) * FAN_ANGLE_STEP;
+            const offsetX =
+              (i - (visibleCount - 1) / 2) * getFanHorizontalStep(visibleCount);
+            return (
+              <CardBack
+                key={i}
+                rotation={rotation}
+                offsetX={offsetX}
+                style={styles.fanCard}
+              />
+            );
+          })}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: '32%',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    paddingTop: 8,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 4,
+  },
+  avatarWrapper: {
+    position: 'relative',
+    alignItems: 'center',
+  },
+  avatarContainer: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: 'rgba(59,130,246,0.1)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden',
+    // borderWidth fixo para não causar layout shift ao alternar o glow
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  avatarTurnGlow: {
+    borderColor: '#3B82F6',
+  },
+  avatarImage: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+  },
+  eliminatedBadge: {
+    position: 'absolute',
+    bottom: -6,
+    backgroundColor: 'rgba(239,68,68,0.12)',
+    borderRadius: 4,
+    paddingHorizontal: 4,
+    paddingVertical: 1,
+  },
+  eliminatedText: {
+    color: '#EF4444',
+    fontSize: 9,
+    fontWeight: '700',
+  },
+  nameColumn: {
+    alignItems: 'flex-start',
+    gap: 2,
+  },
+  opponentName: {
+    fontSize: 13,
+    color: '#E2E8F0',
+    fontWeight: '600',
+  },
+  cardCount: {
+    fontSize: 11,
+    color: '#94A3B8',
+  },
+  fanContainer: {
+    height: 90,
+    width: '100%',
+    position: 'relative',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  fanCard: {
+    position: 'absolute',
+  },
+});

--- a/src/components/organisms/Match/PlayerArea.tsx
+++ b/src/components/organisms/Match/PlayerArea.tsx
@@ -249,7 +249,7 @@ const styles = StyleSheet.create({
   playerInfo: {
     position: 'absolute',
     bottom: 10,
-    left: 12,
+    left: 45,
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,

--- a/src/components/organisms/Match/PlayerArea.tsx
+++ b/src/components/organisms/Match/PlayerArea.tsx
@@ -1,0 +1,285 @@
+import React from 'react';
+import { View, Pressable, Image, StyleSheet } from 'react-native';
+import { Text } from '@/components/atoms/Text';
+import { useTheme } from '@/theme/hooks/useTheme';
+import { AstronautIcon } from '@/components/svg/svgIcons';
+import { CardIcon } from '@/components/svg/CardIcon';
+import { Card } from '@/types/multiplayer.types';
+import {
+  translateCard,
+  getCardIconName,
+  getCardTextColor,
+} from '@/utils/cardTranslations';
+
+// Largura da carta — usada para calcular o offset horizontal do leque
+const CARD_WIDTH = 64;
+
+interface PlayerAreaProps {
+  hand: Card[];
+  isMyTurn: boolean;
+  selectedCardId: string | null;
+  onSelectCard: (card: Card) => void;
+  playerName?: string;
+  playerAvatar?: string;
+}
+
+export function PlayerArea({
+  hand,
+  isMyTurn,
+  selectedCardId,
+  onSelectCard,
+  playerName,
+  playerAvatar,
+}: PlayerAreaProps) {
+  const { fonts } = useTheme();
+
+  // Ângulo máximo de 5° para leque mais suave
+  const angleStep = Math.min(5, 60 / Math.max(hand.length, 1));
+  // Espaçamento horizontal entre cartas: usa o espaço disponível
+  // Quanto mais cartas, menor o passo — mínimo de 20px para sempre mostrar borda
+  const horizontalStep = Math.max(
+    20,
+    Math.min(CARD_WIDTH * 0.85, 200 / Math.max(hand.length - 1, 1)),
+  );
+
+  return (
+    <View style={styles.container}>
+      {hand.length === 0 ? (
+        <View style={styles.emptyState}>
+          <AstronautIcon
+            color="#374151"
+            armColor="#1a1a1a"
+            armStrokeColor="#374151"
+            size={36}
+          />
+          <Text
+            style={[styles.emptyText, { fontFamily: fonts.family.aldrich }]}
+          >
+            Sem cartas na mão
+          </Text>
+        </View>
+      ) : (
+        <View style={styles.fanContainer}>
+          {/* Renderizar não-selecionadas primeiro, selecionada por último (fica acima) */}
+          {[...hand]
+            .sort((a, b) => {
+              const aSelected = a.id === selectedCardId ? 1 : 0;
+              const bSelected = b.id === selectedCardId ? 1 : 0;
+              return aSelected - bSelected;
+            })
+            .map((card) => {
+              const i = hand.indexOf(card);
+              const isSelected = card.id === selectedCardId;
+              const rotation = (i - (hand.length - 1) / 2) * angleStep;
+              const arcOffset = Math.abs(i - (hand.length - 1) / 2) * 2;
+              const horizontalOffset =
+                (i - (hand.length - 1) / 2) * horizontalStep;
+
+              return (
+                <Pressable
+                  key={card.id}
+                  testID={`player-card-${card.id}`}
+                  style={[
+                    styles.card,
+                    {
+                      borderColor: isSelected
+                        ? card.color
+                        : 'rgba(255,255,255,0.15)',
+                      backgroundColor: isSelected
+                        ? '#1E293B'
+                        : 'rgba(15,23,42,0.85)',
+                      opacity: !isMyTurn && !isSelected ? 0.4 : 1,
+                      transform: isSelected
+                        ? [
+                            { translateX: horizontalOffset },
+                            { translateY: -20 },
+                            { rotate: `${rotation}deg` },
+                          ]
+                        : [
+                            { translateX: horizontalOffset },
+                            { translateY: arcOffset },
+                            { rotate: `${rotation}deg` },
+                          ],
+                    },
+                  ]}
+                  onPress={() => onSelectCard(card)}
+                >
+                  {/* Barra de cor no topo */}
+                  <View
+                    style={[
+                      styles.cardColorBar,
+                      { backgroundColor: card.color },
+                    ]}
+                  />
+
+                  {/* Ícone da carta */}
+                  <View style={styles.cardIconWrapper}>
+                    <CardIcon
+                      iconName={getCardIconName(card.type)}
+                      color={card.color}
+                      textColor={getCardTextColor(card.color)}
+                      size={38}
+                    />
+                  </View>
+
+                  {/* Nome curto da carta */}
+                  <Text
+                    style={[
+                      styles.cardType,
+                      {
+                        fontFamily: fonts.family.aldrich,
+                        color: isSelected ? '#F8FAFC' : '#CBD5E1',
+                      },
+                    ]}
+                    numberOfLines={2}
+                  >
+                    {translateCard(card.type)}
+                  </Text>
+
+                  {/* Indicador de seleção */}
+                  {isSelected && (
+                    <View
+                      style={[
+                        styles.selectedDot,
+                        { backgroundColor: card.color },
+                      ]}
+                    />
+                  )}
+                </Pressable>
+              );
+            })}
+        </View>
+      )}
+
+      {/* Info do jogador local — canto inferior esquerdo */}
+      <View style={styles.playerInfo}>
+        <View style={styles.avatarContainer}>
+          {playerAvatar ? (
+            <Image source={{ uri: playerAvatar }} style={styles.avatarImage} />
+          ) : (
+            <AstronautIcon
+              color="#10B981"
+              armColor="#064e3b"
+              armStrokeColor="#10B981"
+              size={28}
+            />
+          )}
+        </View>
+        <View style={styles.playerNameColumn}>
+          {playerName ? (
+            <Text
+              style={[
+                styles.playerNameText,
+                { fontFamily: fonts.family.aldrich },
+              ]}
+              numberOfLines={1}
+            >
+              {playerName}
+            </Text>
+          ) : null}
+          <Text
+            style={[styles.cardCountText, { fontFamily: fonts.family.aldrich }]}
+          >
+            {hand.length} cartas
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: '40%',
+    width: '100%',
+    overflow: 'hidden',
+    paddingBottom: 8,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyText: {
+    color: '#4B5563',
+    fontSize: 11,
+    marginTop: 8,
+  },
+  fanContainer: {
+    flex: 1,
+    position: 'relative',
+    alignItems: 'center',
+  },
+  card: {
+    width: CARD_WIDTH,
+    height: 92,
+    borderRadius: 10,
+    borderCurve: 'continuous',
+    borderWidth: 1.5,
+    position: 'absolute',
+    bottom: 0,
+    overflow: 'hidden',
+    alignItems: 'center',
+  },
+  cardColorBar: {
+    width: '100%',
+    height: 5,
+  },
+  cardIconWrapper: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingTop: 2,
+  },
+  cardType: {
+    fontSize: 7,
+    textAlign: 'center',
+    paddingHorizontal: 3,
+    paddingBottom: 3,
+    textTransform: 'uppercase',
+    letterSpacing: 0.2,
+  },
+  selectedDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    marginBottom: 4,
+  },
+  // Info do jogador local
+  playerInfo: {
+    position: 'absolute',
+    bottom: 10,
+    left: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  avatarContainer: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: 'rgba(16,185,129,0.12)',
+    borderWidth: 1.5,
+    borderColor: 'rgba(16,185,129,0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+  avatarImage: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+  },
+  playerNameColumn: {
+    gap: 1,
+  },
+  playerNameText: {
+    fontSize: 11,
+    color: '#E2E8F0',
+    fontWeight: '600',
+  },
+  cardCountText: {
+    fontSize: 10,
+    color: '#6EE7B7',
+  },
+});

--- a/src/components/organisms/Match/TableArea.tsx
+++ b/src/components/organisms/Match/TableArea.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text } from '@/components/atoms/Text';
+import { useTheme } from '@/theme/hooks/useTheme';
+import { Card } from '@/types/multiplayer.types';
+import { AstronautIcon } from '@/components/svg/svgIcons';
+import { CardIcon } from '@/components/svg/CardIcon';
+import {
+  translateCard,
+  getCardIconName,
+  getCardTextColor,
+} from '@/utils/cardTranslations';
+
+interface TableAreaProps {
+  discardPile: Card[];
+  deckRemaining: number;
+}
+
+export function TableArea({ discardPile, deckRemaining }: TableAreaProps) {
+  const { fonts } = useTheme();
+
+  const topCard =
+    discardPile.length > 0 ? discardPile[discardPile.length - 1] : null;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.cardsRow}>
+        {/* Deck */}
+        <View style={styles.deckWrapper}>
+          <View style={styles.deckCard}>
+            <AstronautIcon color="#4B5563" size={28} />
+          </View>
+          <Text style={[styles.deckText, { fontFamily: fonts.family.aldrich }]}>
+            {deckRemaining}
+          </Text>
+        </View>
+
+        {/* Descarte */}
+        <View style={styles.discardWrapper}>
+          {topCard ? (
+            <View
+              style={[
+                styles.topCard,
+                {
+                  shadowColor: topCard.color,
+                  shadowRadius: 12,
+                  elevation: 8,
+                  borderColor: topCard.color,
+                  borderWidth: 2,
+                },
+              ]}
+            >
+              <View
+                style={[
+                  styles.cardColorBar,
+                  { backgroundColor: topCard.color },
+                ]}
+              />
+              {/* Ícone da carta do topo */}
+              <View style={styles.topCardIconWrapper}>
+                <CardIcon
+                  iconName={getCardIconName(topCard.type)}
+                  color={topCard.color}
+                  textColor={getCardTextColor(topCard.color)}
+                  size={52}
+                />
+              </View>
+              <Text
+                style={[
+                  styles.cardTypeText,
+                  { fontFamily: fonts.family.aldrich },
+                ]}
+              >
+                {translateCard(topCard.type)}
+              </Text>
+            </View>
+          ) : (
+            <View style={[styles.topCard, styles.emptySlot]}>
+              <Text
+                style={[styles.emptyText, { fontFamily: fonts.family.aldrich }]}
+              >
+                Vazio
+              </Text>
+            </View>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 60,
+  },
+  cardsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 32,
+  },
+  deckWrapper: {
+    alignItems: 'center',
+    gap: 8,
+  },
+  deckCard: {
+    width: 72,
+    height: 104,
+    backgroundColor: '#1F2937',
+    borderRadius: 10,
+    borderCurve: 'continuous',
+    borderWidth: 1.5,
+    borderColor: '#374151',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  deckText: {
+    color: '#9CA3AF',
+    fontSize: 13,
+  },
+  discardWrapper: {
+    alignItems: 'center',
+  },
+  topCard: {
+    width: 72,
+    height: 104,
+    borderRadius: 10,
+    borderCurve: 'continuous',
+    backgroundColor: 'rgba(59,130,246,0.08)',
+    overflow: 'hidden',
+    alignItems: 'center',
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.8,
+  },
+  emptySlot: {
+    borderWidth: 2,
+    borderColor: '#374151',
+    borderStyle: 'dashed',
+    justifyContent: 'center',
+    backgroundColor: 'transparent',
+  },
+  cardColorBar: {
+    width: '100%',
+    height: 6,
+  },
+  topCardIconWrapper: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  cardTypeText: {
+    color: '#E2E8F0',
+    fontSize: 9,
+    textAlign: 'center',
+    paddingHorizontal: 4,
+    paddingBottom: 4,
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  emptyText: {
+    color: '#4B5563',
+    fontSize: 12,
+  },
+});

--- a/src/components/organisms/Match/index.ts
+++ b/src/components/organisms/Match/index.ts
@@ -1,11 +1,17 @@
 export { ActivityLogFeed } from './ActivityLogFeed';
+export { ActivityLogOverlay } from './ActivityLogOverlay';
+export { CardBack } from './CardBack';
 export { ComboPlayModal } from './ComboPlayModal';
 export { ForcedDiscardModal } from './ForcedDiscardModal';
 export { GameOverView } from './GameOverView';
+export { HUDOverlay } from './HUDOverlay';
 export { InterruptModal } from './InterruptModal';
 export { MatchHeader } from './MatchHeader';
 export { MatchSidePanel } from './MatchSidePanel';
 export { MatchTopBar } from './MatchTopBar';
+export { OpponentArea } from './OpponentArea';
 export { OpponentList } from './OpponentList';
+export { PlayerArea } from './PlayerArea';
 export { PlayerHand } from './PlayerHand';
+export { TableArea } from './TableArea';
 export { TableCenter } from './TableCenter';

--- a/src/components/svg/CardIcon.tsx
+++ b/src/components/svg/CardIcon.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { View } from 'react-native';
+import FA6Icon from 'react-native-vector-icons/FontAwesome6';
+import { CardIconName } from '@/utils/cardTranslations';
+import {
+  EssenciaIcon,
+  CoringaIcon,
+  ComprarIcon,
+  RoubarIcon,
+  ComprarRoubarIcon,
+  BloqueiaRouboIcon,
+  BloqueiaCompraIcon,
+  RefletirIcon,
+  ArmadilhaIcon,
+  BuracoNegroIcon,
+  VorticeIcon,
+  ReciclarIcon,
+  PoderExtraIcon,
+  NulificarIcon,
+  TrocarLivreIcon,
+} from './svgIcons';
+
+interface CardIconProps {
+  iconName: CardIconName;
+  color: string;
+  /** Cor do texto para ícones de Comprar/Roubar. Default: '#FFFFFF'. */
+  textColor?: string;
+  size?: number;
+}
+
+export function CardIcon({
+  iconName,
+  color,
+  textColor = '#FFFFFF',
+  size = 40,
+}: CardIconProps) {
+  const scale = size / 80;
+
+  // ComprarIcon/RoubarIcon (+2): visual de dois retângulos sobrepostos
+  if (iconName === 'ComprarIcon' || iconName === 'RoubarIcon') {
+    const Icon = iconName === 'ComprarIcon' ? ComprarIcon : RoubarIcon;
+    return (
+      <View
+        style={{
+          width: size,
+          height: size,
+          overflow: 'hidden',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <View style={{ transform: [{ scale }], width: 80, height: 80 }}>
+          <Icon color={color} textColor={textColor} />
+        </View>
+      </View>
+    );
+  }
+
+  // ComprarUmIcon/RoubarUmIcon (+1): retângulo único
+  if (iconName === 'ComprarUmIcon' || iconName === 'RoubarUmIcon') {
+    return (
+      <ComprarRoubarIcon
+        color={color}
+        label="+1"
+        textColor={textColor}
+        size={size}
+      />
+    );
+  }
+
+  // FontAwesome6 — Trocar Próximo/Anterior
+  if (iconName === 'TrocarProximoIcon') {
+    return (
+      <View
+        style={{
+          width: size,
+          height: size,
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <FA6Icon name="arrow-rotate-left" size={size * 0.7} color="#FFFFFF" />
+      </View>
+    );
+  }
+  if (iconName === 'TrocarAnteriorIcon') {
+    return (
+      <View
+        style={{
+          width: size,
+          height: size,
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <FA6Icon name="arrow-rotate-right" size={size * 0.7} color="#FFFFFF" />
+      </View>
+    );
+  }
+
+  // SVGs escalados via transform scale
+  const icon = (() => {
+    switch (iconName) {
+      case 'EssenciaIcon':
+        return <EssenciaIcon color={color} />;
+      case 'CoringaIcon':
+        return <CoringaIcon />;
+      case 'BloqueiaRouboIcon':
+        return <BloqueiaRouboIcon />;
+      case 'BloqueiaCompraIcon':
+        return <BloqueiaCompraIcon />;
+      case 'RefletirIcon':
+        return <RefletirIcon />;
+      case 'ArmadilhaIcon':
+        return <ArmadilhaIcon />;
+      case 'BuracoNegroIcon':
+        return <BuracoNegroIcon color={color} />;
+      case 'VorticeIcon':
+        return <VorticeIcon color={color} />;
+      case 'ReciclarIcon':
+        return <ReciclarIcon color={color} />;
+      case 'PoderExtraIcon':
+        return <PoderExtraIcon color={color} />;
+      case 'NulificarIcon':
+        return <NulificarIcon />;
+      case 'TrocarLivreIcon':
+        return <TrocarLivreIcon />;
+      default:
+        return <EssenciaIcon color={color} />;
+    }
+  })();
+
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        overflow: 'hidden',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <View style={{ transform: [{ scale }], width: 80, height: 80 }}>
+        {icon}
+      </View>
+    </View>
+  );
+}

--- a/src/components/svg/svgIcons.tsx
+++ b/src/components/svg/svgIcons.tsx
@@ -324,7 +324,47 @@ export const RefletirIcon = () => (
   </Svg>
 );
 
-export const ComprarIcon = ({ color }: { color: string }) => (
+/**
+ * Ícone de Comprar/Roubar com fundo colorido e texto +1/+2.
+ * textColor controla a cor do texto — passe '#000000' para fundos claros.
+ */
+export const ComprarRoubarIcon = ({
+  color,
+  label,
+  textColor = '#FFFFFF',
+  size = 80,
+}: {
+  color: string;
+  label: '+1' | '+2';
+  textColor?: string;
+  size?: number;
+}) => (
+  <Svg width={size} height={size} viewBox="0 0 80 80">
+    <Rect x="22.5" y="15" width="35" height="50" rx="4" fill={color} />
+    <SvgText
+      x="40"
+      y="48"
+      fontSize="26"
+      fill={textColor}
+      fontWeight="bold"
+      textAnchor="middle"
+    >
+      {label}
+    </SvgText>
+  </Svg>
+);
+
+/**
+ * Ícone de Comprar +2: dois retângulos sobrepostos (visual original do tutorial).
+ * Usado como alias para manter compatibilidade com TutorialScreen.
+ */
+export const ComprarIcon = ({
+  color,
+  textColor = '#FFFFFF',
+}: {
+  color: string;
+  textColor?: string;
+}) => (
   <Svg width="80" height="80" viewBox="0 0 80 80">
     <Rect
       x="15"
@@ -339,7 +379,7 @@ export const ComprarIcon = ({ color }: { color: string }) => (
       x="32.5"
       y="52"
       fontSize="18"
-      fill="#ffffffff"
+      fill={textColor}
       fontWeight="bold"
       textAnchor="middle"
     >
@@ -350,7 +390,7 @@ export const ComprarIcon = ({ color }: { color: string }) => (
       x="47.5"
       y="47"
       fontSize="18"
-      fill="#ffffffff"
+      fill={textColor}
       fontWeight="bold"
       textAnchor="middle"
     >
@@ -359,7 +399,13 @@ export const ComprarIcon = ({ color }: { color: string }) => (
   </Svg>
 );
 
-export const RoubarIcon = ({ color }: { color: string }) => (
+export const RoubarIcon = ({
+  color,
+  textColor = '#FFFFFF',
+}: {
+  color: string;
+  textColor?: string;
+}) => (
   <Svg width="80" height="80" viewBox="0 0 80 80">
     <Rect
       x="15"
@@ -374,7 +420,7 @@ export const RoubarIcon = ({ color }: { color: string }) => (
       x="32.5"
       y="52"
       fontSize="18"
-      fill="#ffffffff"
+      fill={textColor}
       fontWeight="bold"
       textAnchor="middle"
     >
@@ -385,7 +431,7 @@ export const RoubarIcon = ({ color }: { color: string }) => (
       x="47.5"
       y="47"
       fontSize="18"
-      fill="#ffffffff"
+      fill={textColor}
       fontWeight="bold"
       textAnchor="middle"
     >
@@ -394,7 +440,7 @@ export const RoubarIcon = ({ color }: { color: string }) => (
   </Svg>
 );
 
-export const BuracoNegroIcon = () => (
+export const BuracoNegroIcon = ({ color = '#FFFFFF' }: { color?: string }) => (
   <Svg width="80" height="80" viewBox="0 0 80 80">
     <Circle cx="40" cy="40" r="10" fill="#000000" />
     <Circle
@@ -402,7 +448,7 @@ export const BuracoNegroIcon = () => (
       cy="40"
       r="16"
       fill="none"
-      stroke="#FFFFFF"
+      stroke={color}
       strokeWidth="2.5"
       opacity="0.8"
     />
@@ -411,24 +457,24 @@ export const BuracoNegroIcon = () => (
       cy="40"
       r="22"
       fill="none"
-      stroke="#FFFFFF"
+      stroke={color}
       strokeWidth="2"
       opacity="0.5"
     />
-    <Circle cx="30" cy="30" r="2" fill="#FFFFFF" opacity="0.7" />
-    <Circle cx="50" cy="32" r="2" fill="#FFFFFF" opacity="0.7" />
-    <Circle cx="28" cy="50" r="2" fill="#FFFFFF" opacity="0.7" />
-    <Circle cx="52" cy="48" r="2" fill="#FFFFFF" opacity="0.7" />
+    <Circle cx="30" cy="30" r="2" fill={color} opacity="0.7" />
+    <Circle cx="50" cy="32" r="2" fill={color} opacity="0.7" />
+    <Circle cx="28" cy="50" r="2" fill={color} opacity="0.7" />
+    <Circle cx="52" cy="48" r="2" fill={color} opacity="0.7" />
     <Path
       d="M 22 40 Q 30 37 40 40"
-      stroke="#FFFFFF"
+      stroke={color}
       strokeWidth="1.8"
       fill="none"
       opacity="0.4"
     />
     <Path
       d="M 58 40 Q 50 43 40 40"
-      stroke="#FFFFFF"
+      stroke={color}
       strokeWidth="1.8"
       fill="none"
       opacity="0.4"
@@ -471,9 +517,9 @@ export const VorticeIcon = ({ color }: { color: string }) => (
 
 export const ReciclarIcon = ({ color }: { color: string }) => (
   <Svg width="80" height="80" viewBox="0 0 80 80">
-    <Rect x="25" y="15" width="35" height="50" rx="3" fill={color} />
+    <Rect x="22.5" y="15" width="35" height="50" rx="3" fill={color} />
     <Circle
-      cx="42.5"
+      cx="40"
       cy="40"
       r="14"
       fill="none"
@@ -481,7 +527,7 @@ export const ReciclarIcon = ({ color }: { color: string }) => (
       strokeWidth="2.5"
     />
     <SvgText
-      x="42.5"
+      x="40"
       y="41"
       fontSize="16"
       fill="#000000"
@@ -491,7 +537,7 @@ export const ReciclarIcon = ({ color }: { color: string }) => (
       →
     </SvgText>
     <SvgText
-      x="42.5"
+      x="40"
       y="52"
       fontSize="16"
       fill="#000000"
@@ -505,21 +551,17 @@ export const ReciclarIcon = ({ color }: { color: string }) => (
 
 export const PoderExtraIcon = ({ color }: { color: string }) => (
   <Svg width="80" height="80" viewBox="0 0 80 80">
-    <Rect x="25" y="15" width="35" height="50" rx="3" fill={color} />
-
-    {/* Círculo ao redor */}
+    <Rect x="22.5" y="15" width="35" height="50" rx="3" fill={color} />
     <Circle
-      cx="42.5"
+      cx="40"
       cy="40"
       r="15"
       stroke="#FFFFFF"
       strokeWidth="3"
       fill="none"
     />
-
-    {/* Raio */}
     <Path
-      d="M 45 25 L 37 40 L 43 40 L 40 55 L 48 40 L 42 40 Z"
+      d="M 43 26 L 35 40 L 41 40 L 37 54 L 45 40 L 39 40 Z"
       fill="#FFFFFF"
     />
   </Svg>
@@ -593,6 +635,74 @@ export const CardsIcon = ({ size = 24, color = '#3B82F6' }) => (
   </Svg>
 );
 
+export const NulificarIcon = () => (
+  <Svg width="80" height="80" viewBox="0 0 80 80">
+    <Path
+      d="M 40 12 L 62 22 L 62 44 Q 62 60 40 70 Q 18 60 18 44 L 18 22 Z"
+      fill="#1F2937"
+      stroke="#FFFFFF"
+      strokeWidth="3"
+    />
+    <Line
+      x1="26"
+      y1="26"
+      x2="54"
+      y2="54"
+      stroke="#FFFFFF"
+      strokeWidth="4"
+      strokeLinecap="round"
+    />
+    <Line
+      x1="54"
+      y1="26"
+      x2="26"
+      y2="54"
+      stroke="#FFFFFF"
+      strokeWidth="4"
+      strokeLinecap="round"
+    />
+  </Svg>
+);
+
+export const TrocarLivreIcon = () => (
+  <Svg width="80" height="80" viewBox="0 0 80 80">
+    <Line
+      x1="32"
+      y1="62"
+      x2="32"
+      y2="24"
+      stroke="#FFFFFF"
+      strokeWidth="5"
+      strokeLinecap="round"
+    />
+    <Path
+      d="M 23 34 L 32 20 L 41 34"
+      fill="none"
+      stroke="#FFFFFF"
+      strokeWidth="5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <Line
+      x1="48"
+      y1="18"
+      x2="48"
+      y2="56"
+      stroke="#FFFFFF"
+      strokeWidth="5"
+      strokeLinecap="round"
+    />
+    <Path
+      d="M 39 46 L 48 60 L 57 46"
+      fill="none"
+      stroke="#FFFFFF"
+      strokeWidth="5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
+
 export const AstronautIcon = ({
   color = '#E91E63',
   armColor,
@@ -609,7 +719,6 @@ export const AstronautIcon = ({
 
   return (
     <Svg width={size} height={size} viewBox="0 0 100 100">
-      {/* Braço esquerdo */}
       <Path
         d="M 28 58 Q 10 80 12 95"
         stroke={arm}
@@ -623,8 +732,6 @@ export const AstronautIcon = ({
         strokeWidth="22"
         fill="none"
       />
-
-      {/* Braço direito */}
       <Path
         d="M 72 58 Q 90 80 88 95"
         stroke={arm}
@@ -638,15 +745,12 @@ export const AstronautIcon = ({
         strokeWidth="22"
         fill="none"
       />
-
-      {/* Corpo/Tronco */}
       <Path
         d="M 32 50 Q 24 54 24 68 Q 22 78 22 88 Q 22 94 24 98 L 24 100 L 76 100 L 76 98 Q 78 94 78 88 Q 78 78 76 68 Q 76 54 68 50 Q 62 46 50 46 Q 38 46 32 50 Z"
         fill={color}
         stroke="#1a1a1a"
         strokeWidth="3"
       />
-      {/* Pescoço */}
       <Rect
         x="38"
         y="52"
@@ -657,7 +761,6 @@ export const AstronautIcon = ({
         stroke="#1a1a1a"
         strokeWidth="3"
       />
-      {/* Painel do peito */}
       <Rect
         x="38"
         y="78"
@@ -668,11 +771,9 @@ export const AstronautIcon = ({
         stroke="#1a1a1a"
         strokeWidth="2.5"
       />
-      {/* Pontinhos do painel */}
       <Circle cx="42" cy="86" r="2.2" fill="#abababff" />
       <Circle cx="50" cy="86" r="2.2" fill="#abababff" />
       <Circle cx="58" cy="86" r="2.2" fill="#abababff" />
-      {/* Capacete */}
       <Circle
         cx="50"
         cy="28"
@@ -681,7 +782,6 @@ export const AstronautIcon = ({
         stroke="#1a1a1a"
         strokeWidth="3"
       />
-      {/* Visor */}
       <Circle
         cx="50"
         cy="28"
@@ -690,7 +790,6 @@ export const AstronautIcon = ({
         stroke="#1a1a1a"
         strokeWidth="2.5"
       />
-      {/* Reflexos */}
       <Circle cx="43" cy="22" r="6" fill="rgba(200, 200, 200, 0.7)" />
       <Circle cx="49" cy="25" r="3" fill="rgba(255, 255, 255, 0.5)" />
     </Svg>

--- a/src/contexts/MultiplayerContext.tsx
+++ b/src/contexts/MultiplayerContext.tsx
@@ -166,6 +166,12 @@ export function MultiplayerProvider({ children }: { children: ReactNode }) {
         roomId: payload.roomId,
         roomCode: payload.code,
         phase: 'waiting',
+        gameOver: null,
+        playerView: null,
+        activityLog: [],
+        interrupt: null,
+        forcedDiscard: null,
+        error: null,
       });
     });
 
@@ -173,6 +179,7 @@ export function MultiplayerProvider({ children }: { children: ReactNode }) {
       set({
         players: payload.players,
         phase: 'waiting',
+        gameOver: null,
       });
       setState((prev) => {
         if (!prev.roomCode && prev.joiningRoomCode) {
@@ -267,6 +274,12 @@ export function MultiplayerProvider({ children }: { children: ReactNode }) {
               roomCode: code,
               roomId: response.roomId || null,
               phase: 'waiting',
+              gameOver: null,
+              playerView: null,
+              activityLog: [],
+              interrupt: null,
+              forcedDiscard: null,
+              error: null,
             });
           }
         },
@@ -332,7 +345,13 @@ export function MultiplayerProvider({ children }: { children: ReactNode }) {
   const leaveRoom = useCallback(() => {
     if (!state.roomId) return;
     socketRef.current.emit(EV.ROOM_LEAVE, { roomId: state.roomId });
-    setState(INITIAL);
+
+    // Limpar o estado preservando a conexão do socket
+    setState((prev) => ({
+      ...INITIAL,
+      connected: prev.connected,
+      mySocketId: prev.mySocketId,
+    }));
   }, [state.roomId]);
 
   const resetToLobby = useCallback(() => {

--- a/src/hooks/useCardTimer.ts
+++ b/src/hooks/useCardTimer.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { Card } from '@/types/multiplayer.types';
+
+const TURN_DURATION_MS = 20_000;
+
+interface UseCardTimerParams {
+  isMyTurn: boolean;
+  myHand: Card[];
+  currentTurnIndex: number | undefined;
+  onAutoPlay: (card: Card) => void;
+}
+
+interface UseCardTimerReturn {
+  /** Progresso de 1.0 (início) a 0.0 (expirado) */
+  progress: number;
+  /** Segundos restantes */
+  secondsLeft: number;
+}
+
+/**
+ * Controla o timer de turno do jogador local.
+ * - Só corre quando `isMyTurn === true`
+ * - Reseta ao mudar de turno (`currentTurnIndex`)
+ * - Ao expirar, joga automaticamente a primeira carta da mão
+ */
+export function useCardTimer({
+  isMyTurn,
+  myHand,
+  currentTurnIndex,
+  onAutoPlay,
+}: UseCardTimerParams): UseCardTimerReturn {
+  const [elapsed, setElapsed] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const autoPlayedRef = useRef(false);
+
+  const clearTimer = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  // Reseta quando o turno muda
+  useEffect(() => {
+    setElapsed(0);
+    autoPlayedRef.current = false;
+  }, [currentTurnIndex]);
+
+  // Inicia/para o intervalo baseado em isMyTurn
+  useEffect(() => {
+    if (!isMyTurn) {
+      clearTimer();
+      return;
+    }
+
+    intervalRef.current = setInterval(() => {
+      setElapsed((prev) => {
+        const next = prev + 100;
+        if (next >= TURN_DURATION_MS) {
+          clearTimer();
+          return TURN_DURATION_MS;
+        }
+        return next;
+      });
+    }, 100);
+
+    return clearTimer;
+  }, [isMyTurn, clearTimer]);
+
+  // Auto-play ao expirar
+  useEffect(() => {
+    if (
+      isMyTurn &&
+      elapsed >= TURN_DURATION_MS &&
+      !autoPlayedRef.current &&
+      myHand.length > 0
+    ) {
+      autoPlayedRef.current = true;
+      onAutoPlay(myHand[0]);
+    }
+  }, [elapsed, isMyTurn, myHand, onAutoPlay]);
+
+  const progress = Math.max(0, 1 - elapsed / TURN_DURATION_MS);
+  const secondsLeft = Math.ceil((TURN_DURATION_MS - elapsed) / 1000);
+
+  return { progress, secondsLeft };
+}

--- a/src/screens/Match/MatchScreen.tsx
+++ b/src/screens/Match/MatchScreen.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useCallback } from 'react';
-import { View, StyleSheet, ScrollView } from 'react-native';
+import React, { useEffect, useCallback, useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import { StatusBar } from 'expo-status-bar';
 import Toast from 'react-native-toast-message';
 import * as ScreenOrientation from 'expo-screen-orientation';
 
@@ -10,24 +11,29 @@ import { usePlayerProfile } from '@/hooks/usePlayerProfile';
 import { useMatchPlayer } from '@/hooks/useMatchPlayer';
 import { useCardPlay } from '@/hooks/useCardPlay';
 import { useValidInterrupts } from '@/hooks/useValidInterrupts';
+import { useCardTimer } from '@/hooks/useCardTimer';
 import { Paths } from '@/navigation/paths';
+import { StarField } from '@/components/molecules/StarField';
+import { FloatingGlowDots } from '@/components/organisms/FloatingGlowDots/FloatingGlowDots';
+import { generateStarCoordinates } from '@/utils/generateStarCoordinates';
 
 import {
   InterruptModal,
   ForcedDiscardModal,
   GameOverView,
-  OpponentList,
-  ActivityLogFeed,
-  PlayerHand,
-  TableCenter,
   ComboPlayModal,
-  MatchTopBar,
-  MatchSidePanel,
+  OpponentArea,
+  TableArea,
+  PlayerArea,
+  HUDOverlay,
+  ActivityLogOverlay,
 } from '@/components/organisms/Match';
 
 export default function MatchScreen() {
   const { colors } = useTheme();
   const navigation = useNavigation();
+
+  const stars = useMemo(() => generateStarCoordinates({ quantity: 30 }), []);
 
   const { myId, myAvatar, myNickname } = usePlayerProfile();
 
@@ -48,11 +54,12 @@ export default function MatchScreen() {
     resetToLobby,
   } = useMultiplayerRoom();
 
-  const { isMyTurn, myHand, opponents, currentTurnPlayerId } = useMatchPlayer({
-    playerView,
-    myId,
-    mySocketId,
-  });
+  const { isMyTurn, myHand, opponents, currentTurnPlayerId, me } =
+    useMatchPlayer({
+      playerView,
+      myId,
+      mySocketId,
+    });
 
   const {
     selectedCard,
@@ -64,6 +71,16 @@ export default function MatchScreen() {
   } = useCardPlay({ playCard, currentTurnIndex: playerView?.currentTurnIndex });
 
   const validInteractions = useValidInterrupts({ interrupt, myHand });
+
+  const { progress: timerProgress } = useCardTimer({
+    isMyTurn,
+    myHand,
+    currentTurnIndex: playerView?.currentTurnIndex,
+    onAutoPlay: (card) => {
+      // Chama playCard diretamente com o cardId — sem depender do estado selectedCard
+      playCard({ cardId: card.id });
+    },
+  });
 
   // Força Landscape ao focar na tela, restaura Portrait ao sair
   useFocusEffect(
@@ -103,40 +120,39 @@ export default function MatchScreen() {
 
   return (
     <View style={[styles.root, { backgroundColor: colors.background }]}>
-      {/* ── Área Principal (esquerda) ─────────────────────────────── */}
-      <ScrollView
-        style={styles.mainArea}
-        contentContainerStyle={styles.mainContent}
-        showsVerticalScrollIndicator={false}
-      >
-        <MatchTopBar nickname={myNickname} onSync={syncState} />
+      <StatusBar hidden />
+      {/* Fundo espacial */}
+      <StarField stars={stars} style={StyleSheet.absoluteFillObject} />
+      <FloatingGlowDots />
+      <OpponentArea
+        opponent={opponents[0]}
+        isOpponentTurn={currentTurnPlayerId === opponents[0]?.id}
+      />
 
-        <OpponentList
-          opponents={opponents}
-          currentTurnPlayerId={currentTurnPlayerId}
-        />
+      <TableArea
+        discardPile={playerView?.discardPile ?? []}
+        deckRemaining={playerView?.deck?.remaining ?? 0}
+      />
 
-        <TableCenter
-          discardPile={playerView?.discardPile ?? []}
-          deckRemaining={playerView?.deck?.remaining ?? 0}
-        />
+      <PlayerArea
+        hand={myHand}
+        isMyTurn={isMyTurn}
+        selectedCardId={selectedCard?.id ?? null}
+        onSelectCard={handleSelectCard}
+        playerName={myNickname}
+        playerAvatar={me?.avatar ?? myAvatar}
+      />
 
-        <PlayerHand
-          hand={myHand}
-          isMyTurn={isMyTurn}
-          selectedCardId={selectedCard?.id ?? null}
-          onSelectCard={handleSelectCard}
-        />
-
-        <ActivityLogFeed log={activityLog ?? []} />
-      </ScrollView>
-
-      {/* ── Painel Lateral de Ações (direita) ──────────────────────── */}
-      <MatchSidePanel
+      <HUDOverlay
         isMyTurn={isMyTurn}
         selectedCard={selectedCard}
+        nickname={myNickname}
         onConfirmPlay={handleConfirmPlay}
+        onSync={syncState}
+        timerProgress={timerProgress}
       />
+
+      <ActivityLogOverlay log={activityLog ?? []} />
 
       {/* ── Modais ───────────────────────────────────────────────────── */}
       {interrupt ? (
@@ -178,14 +194,7 @@ export default function MatchScreen() {
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    flexDirection: 'row',
-  },
-  mainArea: {
-    flex: 1,
-  },
-  mainContent: {
-    paddingHorizontal: 12,
-    paddingTop: 8,
-    paddingBottom: 16,
+    flexDirection: 'column',
+    position: 'relative',
   },
 });

--- a/src/screens/SignIn/SignIn.tsx
+++ b/src/screens/SignIn/SignIn.tsx
@@ -17,6 +17,7 @@ import { apiDev } from '@/services/api';
 import Toast from 'react-native-toast-message';
 import { useState } from 'react';
 import { storage } from '@/services/storage';
+import { updateSocketToken } from '@/services/socket';
 
 type Navigation = StackNavigationProp<RootStackParamList>;
 
@@ -58,6 +59,9 @@ export default function SignIn() {
         await storage.saveToken(accessToken);
         await storage.saveUser(username);
         await storage.saveUserId(id);
+
+        // Atualiza o token no socket existente e força reconexão com o novo usuário
+        updateSocketToken(accessToken);
 
         try {
           // Checa se o usuário já tem um profile

--- a/src/screens/Tutorial/TutorialScreen.tsx
+++ b/src/screens/Tutorial/TutorialScreen.tsx
@@ -177,7 +177,7 @@ const TutorialScreen = () => {
         cards: [
           {
             title: 'Buraco Negro',
-            icon: <BuracoNegroIcon color="#8B5CF6" />,
+            icon: <BuracoNegroIcon color="#ffffff" />,
             desc: 'Todos os oponentes descartam 1 carta da cor designada. Se não tiverem, descartam 2 cartas!',
             color: '#FFFFFF',
           },

--- a/src/services/socket.ts
+++ b/src/services/socket.ts
@@ -65,3 +65,22 @@ export function disconnectSocket() {
     socket = null;
   }
 }
+
+/**
+ * Updates the JWT on the existing socket and forces a reconnect so the
+ * server re-authenticates with the new user's token. This must be called
+ * after login so the socket session is bound to the correct user profile.
+ *
+ * We intentionally do NOT destroy the singleton here — the MultiplayerProvider
+ * holds a ref to this same instance and would lose all event listeners if we
+ * replaced it.
+ */
+export function updateSocketToken(token: string) {
+  if (socket) {
+    socket.auth = { token };
+    if (socket.connected) {
+      socket.disconnect();
+      socket.connect();
+    }
+  }
+}

--- a/src/utils/cardTranslations.ts
+++ b/src/utils/cardTranslations.ts
@@ -119,3 +119,68 @@ export function translateLog(text: string): string {
 
   return translated;
 }
+
+// ─── Mapeamento CardType → ícone SVG ─────────────────────────────────────────
+// Retorna o nome do componente de ícone correspondente ao tipo de carta.
+// Usado pelo PlayerArea e TableArea para renderizar o ícone correto em cada carta.
+export type CardIconName =
+  | 'EssenciaIcon'
+  | 'CoringaIcon'
+  | 'ComprarIcon'
+  | 'ComprarUmIcon'
+  | 'RoubarIcon'
+  | 'RoubarUmIcon'
+  | 'BloqueiaRouboIcon'
+  | 'BloqueiaCompraIcon'
+  | 'RefletirIcon'
+  | 'ArmadilhaIcon'
+  | 'BuracoNegroIcon'
+  | 'VorticeIcon'
+  | 'ReciclarIcon'
+  | 'PoderExtraIcon'
+  | 'NulificarIcon'
+  | 'TrocarProximoIcon'
+  | 'TrocarAnteriorIcon'
+  | 'TrocarLivreIcon';
+
+export const CARD_ICON_MAP: Record<string, CardIconName> = {
+  essence: 'EssenciaIcon',
+  joker: 'CoringaIcon',
+  buy_plus_1: 'ComprarUmIcon',
+  buy_plus_2: 'ComprarIcon',
+  steal_next_1: 'RoubarUmIcon',
+  steal_next_2: 'RoubarIcon',
+  steal_prev_1: 'RoubarUmIcon',
+  steal_prev_2: 'RoubarIcon',
+  steal_any_1: 'RoubarUmIcon',
+  block_steal: 'BloqueiaRouboIcon',
+  block_purchase: 'BloqueiaCompraIcon',
+  reflect: 'RefletirIcon',
+  trap: 'ArmadilhaIcon',
+  black_hole: 'BuracoNegroIcon',
+  vortex: 'VorticeIcon',
+  recycle: 'ReciclarIcon',
+  extra_power: 'PoderExtraIcon',
+  nullify: 'NulificarIcon',
+  swap_next_hand: 'TrocarProximoIcon',
+  swap_prev_hand: 'TrocarAnteriorIcon',
+  swap_any_hand: 'TrocarLivreIcon',
+};
+
+/** Cores de fundo claras (do servidor) que precisam de texto preto */
+const LIGHT_CARD_COLORS = new Set([
+  'yellow',
+  'white',
+  '#F59E0B',
+  '#D1D5DB',
+  '#FBBF24',
+]);
+
+export function getCardIconName(type: string): CardIconName {
+  return CARD_ICON_MAP[type] ?? 'EssenciaIcon';
+}
+
+/** Retorna '#000000' para cores claras, '#FFFFFF' para escuras */
+export function getCardTextColor(color: string): string {
+  return LIGHT_CARD_COLORS.has(color) ? '#000000' : '#FFFFFF';
+}


### PR DESCRIPTION
Este PR transforma a tela de partida de um layout com ScrollView vertical e painel lateral para uma experiência imersiva de mesa de jogo em landscape, com ícones SVG nas cartas e novas mecânicas de UX.

**O que foi feito:**

- **Layout de Mesa Imersivo:** Migração do layout para três zonas fixas empilhadas verticalmente (OpponentArea, TableArea, PlayerArea) sem ScrollView, com HUD sobreposto e fundo espacial com estrelas e pontos brilhantes.
- **Ícones nas Cartas:** Criação de CardIcon e mapeamento de todos os 19 tipos de carta para ícones SVG dedicados, incluindo 4 novos ícones (Anular, Trocar Próximo, Trocar Anterior, Trocar Livre). Ícones de Comprar/Roubar com contraste automático para fundos claros (amarelo/branco).
- **Timer de Turno:** Implementação de useCardTimer — 20 segundos por turno com barra de progresso, verde→amarelo→vermelho no HUD. Ao expirar, joga automaticamente a primeira carta da mão.
- **Polimento Visual:** Leque de cartas com offset horizontal, carta selecionada sempre acima das demais, avatar do jogador local com nome e contagem, log de últimas jogadas reposicionado à direita abaixo do indicador de turno, tela fullscreen sem status bar.
- **Correção de bug de reconexão:** Ajuste do bug que ao logar com um novo usuário não atualizava o id na conexão do socket, fazendo com que fosse buscado e retornado o avatar do usuário anterior ao entrar no Lobby e na Partida.